### PR TITLE
Fix usm fill multiple blits benchmark

### DIFF
--- a/source/benchmarks/memory_benchmark/gtest/usm_fill_multiple_blits.cpp
+++ b/source/benchmarks/memory_benchmark/gtest/usm_fill_multiple_blits.cpp
@@ -39,6 +39,6 @@ INSTANTIATE_TEST_SUITE_P(
         ::CommonGtestArgs::allApis(),
         ::testing::Values(UsmMemoryPlacement::Device),
         ::testing::Values(512 * megaByte),
-        ::testing::Values(16),
+        ::testing::Values(1),
         ::testing::Values(BufferContents::Zeros, BufferContents::Random),
         ::testing::Values("000000001", "000000010", "000000111", "111111111")));


### PR DESCRIPTION
Link copy engine does not support a pattern size greater than 1

Signed-off-by: Kamil Kopryk <kamil.kopryk@intel.com>