### PR TITLE
Add option to use locally installed Unified Runtime

### DIFF
--- a/source/framework/ur/CMakeLists.txt
+++ b/source/framework/ur/CMakeLists.txt
@@ -8,11 +8,17 @@ if (NOT BUILD_UR)
     return()
 endif()
 
-if(BENCHMARK_UR_SOURCE_DIR)
-    add_subdirectory(
-        ${BENCHMARK_UR_SOURCE_DIR}
-        ${CMAKE_CURRENT_BINARY_DIR}/unified-runtime)
+find_package(unified-runtime)
+
+if(${unified-runtime_FOUND} AND NOT BENCHMARK_UR_OVERRIDE_FETCH_CONTENT_REPO AND NOT BENCHMARK_UR_OVERRIDE_FETCH_CONTENT_TAG)
+
+    message(STATUS "Unified Runtime installation found")
+
+    add_library(ur_loader ALIAS unified-runtime::ur_loader)
+    add_library(ur_headers ALIAS unified-runtime::ur_headers)
+
 else()
+
     include(FetchContent)
 
     set(UMF_DISABLE_HWLOC ON CACHE INTERNAL "")
@@ -22,9 +28,6 @@ else()
     set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
     set(UNIFIED_RUNTIME_TAG main)
 
-    message(STATUS
-      "Will fetch Unified Runtime from ${UNIFIED_RUNTIME_REPO} at ${UNIFIED_RUNTIME_TAG}")
-
     if(BENCHMARK_UR_OVERRIDE_FETCH_CONTENT_REPO)
         set(UNIFIED_RUNTIME_REPO "${BENCHMARK_UR_OVERRIDE_FETCH_CONTENT_REPO}")
     endif()
@@ -32,7 +35,9 @@ else()
         set(UNIFIED_RUNTIME_TAG "${BENCHMARK_UR_OVERRIDE_FETCH_CONTENT_TAG}")
     endif()
 
-    message(STATUS "Will fetch Unified Runtime from ${UNIFIED_RUNTIME_REPO}")
+    message(STATUS
+      "Will fetch Unified Runtime from ${UNIFIED_RUNTIME_REPO} at ${UNIFIED_RUNTIME_TAG}")
+
     FetchContent_Declare(unified-runtime
     GIT_REPOSITORY    ${UNIFIED_RUNTIME_REPO}
     GIT_TAG           ${UNIFIED_RUNTIME_TAG}
@@ -40,13 +45,12 @@ else()
 
     FetchContent_GetProperties(unified-runtime)
     FetchContent_MakeAvailable(unified-runtime)
+
 endif()
 
 # Define target
 set(API_NAME ur)
-
 set(TARGET_NAME compute_benchmarks_framework_${API_NAME})
-
 add_library(${TARGET_NAME} STATIC ur.cpp ur.h error.h)
 target_include_directories(${TARGET_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(${TARGET_NAME} PUBLIC compute_benchmarks_framework ur_loader ur_headers)


### PR DESCRIPTION
Add support for using UR binary through find_package instead of compiling from local sources. Before this change compute-benchmarks was always building UR from sources which was unnecessary since UR is already build as a part of SYCL on UR CI.