### PR TITLE
Update SYCL header to correct one

### DIFF
--- a/source/framework/sycl/sycl.h
+++ b/source/framework/sycl/sycl.h
@@ -9,7 +9,7 @@
 
 #include "framework/test_case/test_case.h"
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 namespace SYCL {
 namespace sycl = ::sycl;


### PR DESCRIPTION
The SYCL header changed from CL/sycl.hpp to sycl/sycl.hpp quite some time ago.