### PR TITLE
Support SYCL eventless enqueue functions

### DIFF
--- a/source/benchmarks/api_overhead_benchmark/definitions/submit_kernel.h
+++ b/source/benchmarks/api_overhead_benchmark/definitions/submit_kernel.h
@@ -17,6 +17,7 @@ struct SubmitKernelArguments : TestCaseArgumentContainer {
     PositiveIntegerArgument numKernels;
     PositiveIntegerArgument kernelExecutionTime;
     BooleanArgument measureCompletionTime;
+    BooleanArgument useEnqueueFunctions;
 
     SubmitKernelArguments()
         : useProfiling(*this, "Profiling", "Create the queue with the enable_profiling property"),
@@ -24,7 +25,8 @@ struct SubmitKernelArguments : TestCaseArgumentContainer {
           discardEvents(*this, "DiscardEvents", "Create the queue with the discard_events property"),
           numKernels(*this, "NumKernels", "Number of kernels to submit to the queue"),
           kernelExecutionTime(*this, "KernelExecTime", "Approximately how long a single kernel executes, in us"),
-          measureCompletionTime(*this, "MeasureCompletion", "Measures time taken to complete the submission (default is to measure only submit calls)") {}
+          measureCompletionTime(*this, "MeasureCompletion", "Measures time taken to complete the submission (default is to measure only submit calls)"),
+          useEnqueueFunctions(*this, "EnqueueFunctions", "Use the event-less SYCL enqueue functions instead of queue member functions") {}
 };
 
 struct SubmitKernel : TestCase<SubmitKernelArguments> {

--- a/source/benchmarks/api_overhead_benchmark/implementations/sycl/submit_kernel_sycl.cpp
+++ b/source/benchmarks/api_overhead_benchmark/implementations/sycl/submit_kernel_sycl.cpp
@@ -72,7 +72,11 @@ static TestResult run(const SubmitKernelArguments &arguments, Statistics &statis
     for (auto i = 0u; i < arguments.iterations; i++) {
         timer.measureStart();
         for (auto iteration = 0u; iteration < arguments.numKernels; iteration++) {
-            queue.parallel_for(range, eat_time);
+            if (arguments.useEnqueueFunctions) {
+                sycl::ext::oneapi::experimental::nd_launch(queue, range, eat_time);
+            } else {
+                queue.parallel_for(range, eat_time);
+            }
         }
 
         if (!arguments.measureCompletionTime) {


### PR DESCRIPTION
This adds a switch to use new event-less enqueue functions for the SYCL submit kernel benchmark.
