### PR TITLE
Fix build error: decrement of object of volatile-qualified type 'volatile int' is deprecated.

### DIFF
--- a/source/benchmarks/api_overhead_benchmark/implementations/sycl/submit_barrier_sycl.cpp
+++ b/source/benchmarks/api_overhead_benchmark/implementations/sycl/submit_barrier_sycl.cpp
@@ -33,8 +33,9 @@ static TestResult run(const SubmitBarrierArguments &arguments, Statistics &stati
     const auto eat_time = [=]([[maybe_unused]] auto u) {
         if (kernelOperationsCount > 4) {
             volatile int value = kernelOperationsCount;
-            while (--value)
-                ;
+            while (value) {
+                value = value -1;
+            }
         }
     };
 

--- a/source/benchmarks/api_overhead_benchmark/implementations/sycl/submit_kernel_sycl.cpp
+++ b/source/benchmarks/api_overhead_benchmark/implementations/sycl/submit_kernel_sycl.cpp
@@ -47,8 +47,9 @@ static TestResult run(const SubmitKernelArguments &arguments, Statistics &statis
     const auto eat_time = [=]([[maybe_unused]] auto u) {
         if (kernelOperationsCount > 4) {
             volatile int value = kernelOperationsCount;
-            while (--value)
-                ;
+            while (value) {
+                value = value - 1;
+            }
         }
     };
 

--- a/source/benchmarks/graph_api_benchmark/implementations/sycl/submit_graph_sycl.cpp
+++ b/source/benchmarks/graph_api_benchmark/implementations/sycl/submit_graph_sycl.cpp
@@ -56,8 +56,9 @@ static TestResult run([[maybe_unused]] const SubmitGraphArguments &arguments, St
         [[maybe_unused]] const auto eat_time = [=]([[maybe_unused]] auto u) {
             if (kernelOperationsCount > 4) {
                 volatile int value = kernelOperationsCount;
-                while (--value)
-                    ;
+                while (value) {
+                    value = value - 1;
+                }
             }
         };
 


### PR DESCRIPTION
This PR target to fix the build error as follow:  

compute-benchmarks/source/benchmarks/api_overhead_benchmark/implementations/sycl/submit_barrier_sycl.cpp:36:20: error: decrement of object of volatile-qualified type 'volatile int' is deprecated [-Werror,-Wdeprecated-volatile]
   36 |             while (--value)
      |                    ^